### PR TITLE
Feature/etf list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ccxt == 1.17.191
 dash==0.43.0
 dash-daq==0.1.0
 simplejson==3.16.0
+html5lib == 1.0.1

--- a/zvt/api/technical.py
+++ b/zvt/api/technical.py
@@ -90,11 +90,13 @@ def get_securities(security_list: List[str] = None,
                     session=session, order=order, limit=limit, index=index, index_is_time=index_is_time)
 
 
-def get_kdata(security_id, level=TradingLevel.LEVEL_1DAY.value, provider='eastmoney', columns=None,
+def get_kdata(security_id, data_schema=None, level=TradingLevel.LEVEL_1DAY.value, provider='eastmoney', columns=None,
               return_type='df', start_timestamp=None, end_timestamp=None,
               filters=None, session=None, order=None, limit=None):
     security_type, exchange, code = decode_security_id(security_id)
-    data_schema = get_kdata_schema(security_type, level=level)
+
+    if data_schema is None:
+        data_schema = get_kdata_schema(security_type, level=level)
 
     return get_data(data_schema=data_schema, security_id=security_id, level=level, provider=provider, columns=columns,
                     return_type=return_type,

--- a/zvt/domain/common.py
+++ b/zvt/domain/common.py
@@ -166,6 +166,7 @@ class StockCategory(enum.Enum):
     concept = 'concept'
     area = 'area'
     main = 'main'
+    etf = 'etf'
 
 
 class ReportPeriod(enum.Enum):

--- a/zvt/domain/common.py
+++ b/zvt/domain/common.py
@@ -18,6 +18,7 @@ Stock1HKdataBase = declarative_base()
 Stock1DKdataBase = declarative_base()
 Stock1WKKdataBase = declarative_base()
 
+ETF1DKdataBase = declarative_base()
 Index1DKdataBase = declarative_base()
 
 FinanceBase = declarative_base()
@@ -64,7 +65,9 @@ class StoreCategory(enum.Enum):
     stock_1d_kdata = 'stock_1d_kdata'
     stock_1wk_kdata = 'stock_1wk_kdata'
 
+    etf_1d_kdata = 'etf_1d_kdata'
     index_1d_kdata = 'index_1d_kdata'
+
     finance = 'finance'
     dividend_financing = 'dividend_financing'
     holder = 'holder'
@@ -91,6 +94,7 @@ provider_map_category = {
                          StoreCategory.trading],
 
     Provider.SINA: [StoreCategory.meta,
+                    StoreCategory.etf_1d_kdata,
                     StoreCategory.stock_1d_kdata,
                     StoreCategory.money_flow],
 
@@ -128,6 +132,7 @@ category_map_db = {
     StoreCategory.stock_1d_kdata: Stock1DKdataBase,
     StoreCategory.stock_1wk_kdata: Stock1WKKdataBase,
 
+    StoreCategory.etf_1d_kdata: ETF1DKdataBase,
     StoreCategory.index_1d_kdata: Index1DKdataBase,
     StoreCategory.finance: FinanceBase,
     StoreCategory.dividend_financing: DividendFinancingBase,

--- a/zvt/domain/meta.py
+++ b/zvt/domain/meta.py
@@ -34,6 +34,9 @@ class Index(MetaBase):
 
     stocks = relationship('StockIndex', back_populates="indices")
 
+    def __repr__(self):
+        return f'[{self.name} - {self.code}]'
+
 
 # 个股
 class Stock(MetaBase):

--- a/zvt/domain/quote.py
+++ b/zvt/domain/quote.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from sqlalchemy import Column, String, DateTime, Float
 
-from zvt.domain.common import Stock1DKdataBase, Index1DKdataBase, Stock1HKdataBase, Stock15MKdataBase, \
+from zvt.domain.common import Stock1DKdataBase, ETF1DKdataBase, Index1DKdataBase, Stock1HKdataBase, Stock15MKdataBase, \
     Coin15MKdataBase, Coin1HKdataBase, Coin1DKdataBase, Coin1MKdataBase, Coin5MKdataBase, Coin1WKKdataBase, \
     Stock1MKdataBase, Stock5MKdataBase, Stock30MKdataBase, Stock1WKKdataBase, CoinTickKdataBase
 
@@ -98,6 +98,15 @@ class Stock5MKdata(Stock5MKdataBase, StockKdataCommon):
 
 class Stock1MKdata(Stock1MKdataBase, StockKdataCommon):
     __tablename__ = 'stock_1m_kdata'
+
+
+class ETF1DKdata(ETF1DKdataBase, KdataCommon):
+    __tablename__ = 'etf_1d_kdata'
+
+    # 累计净值（货币 ETF 为七日年化)
+    cumulative_net_value = Column(Float)
+    # 净值增长率
+    change_pct = Column(Float)
 
 
 class Index1DKdata(Index1DKdataBase, KdataCommon):

--- a/zvt/recorders/common/china_etf_list_spider.py
+++ b/zvt/recorders/common/china_etf_list_spider.py
@@ -45,7 +45,7 @@ class ChinaETFListSpider(Recorder):
 
         # 抓取深市 ETF 成分股
         self.download_sz_etf_component(df)
-        self.logger.info('沪市 ETF 成分股抓取完成...')
+        self.logger.info('深市 ETF 成分股抓取完成...')
 
     def persist_etf_list(self, df: pd.DataFrame, exchange: str):
         if df is None:

--- a/zvt/recorders/common/china_etf_list_spider.py
+++ b/zvt/recorders/common/china_etf_list_spider.py
@@ -1,60 +1,193 @@
 # -*- coding: utf-8 -*-
 
 import io
+import re
 
 import demjson
 import requests
 import pandas as pd
 
-from zvt.api.technical import init_securities
+from zvt.api.common import china_stock_code_to_id
+from zvt.api.technical import init_securities, df_to_db
+from zvt.domain import Provider, StockIndex, StockCategory
 from zvt.recorders.consts import DEFAULT_SH_ETF_LIST_HEADER
-from zvt.domain import Provider, Index
 from zvt.recorders.recorder import Recorder
 
 
 class ChinaETFListSpider(Recorder):
-    data_schema = Index
+    data_schema = StockIndex
 
-    def __init__(self, batch_size=10, force_update=False, sleeping_time=10, provider=Provider.EXCHANGE) -> None:
+    def __init__(self, batch_size=10, force_update=False, sleeping_time=2.0, provider=Provider.EXCHANGE) -> None:
         self.provider = provider
         super().__init__(batch_size, force_update, sleeping_time)
 
     def run(self):
-        url = 'http://query.sse.com.cn/commonQuery.do?sqlId=COMMON_SSE_ZQPZ_ETFLB_L_NEW&_=1561697608673'
+        # 抓取沪市 ETF 列表
+        url = 'http://query.sse.com.cn/commonQuery.do?sqlId=COMMON_SSE_ZQPZ_ETFLB_L_NEW'
+        response = requests.get(url, headers=DEFAULT_SH_ETF_LIST_HEADER)
+        response_dict = demjson.decode(response.text)
 
-        resp = requests.get(url, headers=DEFAULT_SH_ETF_LIST_HEADER)
-        self.download_etf_list(response=resp, exchange='sh')
+        df = pd.DataFrame(response_dict.get('result', []))
+        self.persist_etf_list(df, exchange='sh')
+        self.logger.info('沪市 ETF 列表抓取完成...')
 
-        url = 'http://www.szse.cn/api/report/ShowReport?SHOWTYPE=xlsx&CATALOGID=1105&TABKEY=tab1&selectJjlb=ETF'
+        # 抓取沪市 ETF 成分股
+        self.download_sh_etf_component(df)
+        self.logger.info('沪市 ETF 成分股抓取完成...')
 
-        resp = requests.get(url)
-        self.download_etf_list(response=resp, exchange='sz')
+        # 抓取深市 ETF 列表
+        url = 'http://www.szse.cn/api/report/ShowReport?SHOWTYPE=xlsx&CATALOGID=1945'
+        response = requests.get(url)
 
-    def download_etf_list(self, response: requests.Response, exchange: str) -> None:
-        df = None
+        df = pd.read_excel(io.BytesIO(response.content), dtype=str)
+        self.persist_etf_list(df, exchange='sz')
+        self.logger.info('深市 ETF 列表抓取完成...')
+
+        # 抓取深市 ETF 成分股
+        self.download_sz_etf_component(df)
+        self.logger.info('沪市 ETF 成分股抓取完成...')
+
+    def persist_etf_list(self, df: pd.DataFrame, exchange: str):
+        if df is None:
+            return
+
+        df = df.copy()
         if exchange == 'sh':
-            response_dict = demjson.decode(response.text)
-            df = pd.DataFrame(response_dict['result'])
-            if df is not None:
-                df = df[['FUND_ID', 'FUND_NAME']]
-                df.columns = ['code', 'name']
-
+            df = df[['FUND_ID', 'FUND_NAME']]
         elif exchange == 'sz':
-            df = pd.read_excel(io.BytesIO(response.content), dtype=str, parse_dates=['上市日期'])
-            if df is not None:
-                df = df[['基金代码', '基金简称', '上市日期']]
-                df.columns = ['code', 'name', 'timestamp']
+            df = df[['证券代码', '证券简称']]
 
-        if df is not None:
-            df['id'] = df['code'].apply(lambda x: f'index_{exchange}_{x}')
-            df['exchange'] = exchange
-            df['type'] = 'index'
-            df['category'] = 'etf'
+        df.columns = ['code', 'name']
+        df['id'] = df['code'].apply(lambda code: f'index_{exchange}_{code}')
+        df['exchange'] = exchange
+        df['type'] = 'index'
+        df['category'] = StockCategory.etf.value
 
-            df = df.dropna(axis=0, how='any')
-            df = df.drop_duplicates(subset='id', keep='last')
+        df = df.dropna(axis=0, how='any')
+        df = df.drop_duplicates(subset='id', keep='last')
 
-            init_securities(df, security_type='index', provider=self.provider)
+        init_securities(df, security_type='index', provider=self.provider)
+
+    def download_sh_etf_component(self, df: pd.DataFrame):
+        """
+        ETF_CLASS => 1. 单市场 ETF 2.跨市场 ETF 3. 跨境 ETF
+                        5. 债券 ETF 6. 黄金 ETF
+        :param df: ETF 列表数据
+        :return: None
+        """
+        query_url = 'http://query.sse.com.cn/infodisplay/queryConstituentStockInfo.do?' \
+                    'isPagination=false&type={}&etfClass={}'
+
+        etf_df = df[(df['ETF_CLASS'] == '1') | (df['ETF_CLASS'] == '2')]
+        etf_df = self.populate_sh_etf_type(etf_df)
+
+        for _, etf in etf_df.iterrows():
+            url = query_url.format(etf['ETF_TYPE'], etf['ETF_CLASS'])
+            response = requests.get(url, headers=DEFAULT_SH_ETF_LIST_HEADER)
+            response_dict = demjson.decode(response.text)
+            response_df = pd.DataFrame(response_dict.get('result', []))
+
+            etf_code = etf['FUND_ID']
+            index_id = f'index_sh_{etf_code}'
+            response_df = response_df[['instrumentId']]
+            response_df['id'] = response_df['instrumentId'].apply(lambda code: f'{index_id}_{china_stock_code_to_id(code)}')
+            response_df['stock_id'] = response_df['instrumentId'].apply(lambda code: china_stock_code_to_id(code))
+            response_df['index_id'] = index_id
+            response_df.drop('instrumentId', axis=1, inplace=True)
+
+            df_to_db(data_schema=self.data_schema, df=response_df, provider=self.provider)
+            self.logger.info(f'{etf["FUND_NAME"]} - {etf_code} 成分股抓取完成...')
+
+            self.sleep()
+
+    def download_sz_etf_component(self, df: pd.DataFrame):
+        query_url = 'http://vip.stock.finance.sina.com.cn/corp/go.php/vII_NewestComponent/indexid/{}.phtml'
+
+        self.parse_sz_etf_underlying_index(df)
+        for _, etf in df.iterrows():
+            underlying_index = etf['拟合指数']
+            etf_code = etf['证券代码']
+
+            if len(underlying_index) == 0:
+                self.logger.info(f'{etf["证券简称"]} - {etf_code} 非 A 股市场指数，跳过...')
+                continue
+
+            url = query_url.format(underlying_index)
+            response = requests.get(url)
+            response.encoding = 'gbk'
+
+            try:
+                dfs = pd.read_html(response.text, header=1)
+            except ValueError as error:
+                self.logger.error(f'HTML parse error: {error}, response: {response.text}')
+                continue
+
+            if len(dfs) < 4:
+                continue
+
+            response_df = dfs[3].copy()
+            response_df = response_df.dropna(axis=1, how='any')
+            response_df['品种代码'] = response_df['品种代码'].apply(lambda x: f'{x:06d}')
+
+            index_id = f'index_sz_{etf_code}'
+            response_df = response_df[['品种代码']]
+
+            response_df['id'] = response_df['品种代码'].apply(lambda code: f'{index_id}_{china_stock_code_to_id(code)}')
+            response_df['stock_id'] = response_df['品种代码'].apply(lambda code: china_stock_code_to_id(code))
+            response_df['index_id'] = index_id
+            response_df.drop('品种代码', axis=1, inplace=True)
+
+            df_to_db(data_schema=self.data_schema, df=response_df, provider=self.provider)
+            self.logger.info(f'{etf["证券简称"]} - {etf_code} 成分股抓取完成...')
+
+            self.sleep()
+
+    @staticmethod
+    def populate_sh_etf_type(df: pd.DataFrame):
+        """
+        填充沪市 ETF 代码对应的 TYPE 到列表数据中
+        :param df: ETF 列表数据
+        :return: 包含 ETF 对应 TYPE 的列表数据
+        """
+        query_url = 'http://query.sse.com.cn/infodisplay/queryETFNewAllInfo.do?' \
+                    'isPagination=false&type={}&pageHelp.pageSize=25'
+
+        type_df = pd.DataFrame()
+        for etf_class in [1, 2]:
+            url = query_url.format(etf_class)
+            response = requests.get(url, headers=DEFAULT_SH_ETF_LIST_HEADER)
+            response_dict = demjson.decode(response.text)
+            response_df = pd.DataFrame(response_dict.get('result', []))
+            response_df = response_df[['fundid1', 'etftype']]
+
+            type_df = pd.concat([type_df, response_df])
+
+        result_df = df.copy()
+        result_df = result_df.sort_values(by='FUND_ID').reset_index(drop=True)
+        type_df = type_df.sort_values(by='fundid1').reset_index(drop=True)
+
+        result_df['ETF_TYPE'] = type_df['etftype']
+
+        return result_df
+
+    @staticmethod
+    def parse_sz_etf_underlying_index(df: pd.DataFrame):
+        """
+        解析深市 ETF 对应跟踪的指数代码
+        :param df: ETF 列表数据
+        :return: 解析完成 ETF 对应指数代码的列表数据
+        """
+        def parse_index(text):
+            if len(text) == 0:
+                return ''
+
+            result = re.search(r"(\d+).*", text)
+            if result is None:
+                return ''
+            else:
+                return result.group(1)
+
+        df['拟合指数'] = df['拟合指数'].apply(parse_index)
 
 
 if __name__ == '__main__':

--- a/zvt/recorders/common/china_etf_list_spider.py
+++ b/zvt/recorders/common/china_etf_list_spider.py
@@ -17,7 +17,7 @@ from zvt.recorders.recorder import Recorder
 class ChinaETFListSpider(Recorder):
     data_schema = StockIndex
 
-    def __init__(self, batch_size=10, force_update=False, sleeping_time=2.0, provider=Provider.EXCHANGE) -> None:
+    def __init__(self, batch_size=10, force_update=False, sleeping_time=10.0, provider=Provider.EXCHANGE) -> None:
         self.provider = provider
         super().__init__(batch_size, force_update, sleeping_time)
 

--- a/zvt/recorders/common/china_etf_list_spider.py
+++ b/zvt/recorders/common/china_etf_list_spider.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+import demjson
+import requests
+import pandas as pd
+
+from zvt.api.technical import init_securities
+from zvt.recorders.consts import DEFAULT_SH_ETF_LIST_HEADER
+from zvt.domain import Provider, Index
+from zvt.recorders.recorder import Recorder
+
+
+class ChinaETFListSpider(Recorder):
+    data_schema = Index
+
+    def __init__(self, batch_size=10, force_update=False, sleeping_time=10, provider=Provider.EXCHANGE) -> None:
+        self.provider = provider
+        super().__init__(batch_size, force_update, sleeping_time)
+
+    def run(self):
+        url = 'http://query.sse.com.cn/commonQuery.do?sqlId=COMMON_SSE_ZQPZ_ETFLB_L_NEW&_=1561697608673'
+
+        resp = requests.get(url, headers=DEFAULT_SH_ETF_LIST_HEADER)
+        self.download_etf_list(response=resp, exchange='sh')
+
+    def download_etf_list(self, response: requests.Response, exchange: str) -> None:
+        df = None
+        if exchange == 'sh':
+            response_dict = demjson.decode(response.text)
+            df = pd.DataFrame(response_dict['result'])
+
+            if df is not None:
+                df = df[['FUND_ID', 'FUND_NAME']]
+
+        elif exchange == 'sz':
+            pass
+
+        if df is not None:
+            df.columns = ['code', 'name']
+
+            df['id'] = df['code'].apply(lambda x: f'index_{exchange}_{x}')
+            df['exchange'] = exchange
+            df['type'] = 'index'
+            df['category'] = 'etf'
+
+            df = df.dropna(axis=0, how='any')
+            df = df.drop_duplicates(subset='id', keep='last')
+
+            init_securities(df, security_type='index', provider=self.provider)
+
+
+if __name__ == '__main__':
+    spider = ChinaETFListSpider(provider=Provider.EXCHANGE)
+    spider.run()

--- a/zvt/recorders/common/china_stock_list_spider.py
+++ b/zvt/recorders/common/china_stock_list_spider.py
@@ -63,5 +63,5 @@ class ChinaStockListSpider(Recorder):
 
 
 if __name__ == '__main__':
-    spider = ChinaStockListSpider(provider=Provider.EASTMONEY)
+    spider = ChinaStockListSpider(provider=Provider.EXCHANGE)
     spider.run()

--- a/zvt/recorders/consts.py
+++ b/zvt/recorders/consts.py
@@ -131,3 +131,8 @@ Accept-Language: zh-CN,zh;q=0.9
 Cookie: yfx_c_g_u_id_10000042=_ck19062609443812815766114343798; VISITED_COMPANY_CODE=%5B%22510300%22%5D; VISITED_FUND_CODE=%5B%22510300%22%5D; VISITED_MENU=%5B%228307%22%2C%228823%22%2C%228547%22%2C%228556%22%2C%228549%22%2C%2210848%22%2C%228550%22%5D; yfx_f_l_v_t_10000042=f_t_1561513478278__r_t_1561692626758__v_t_1561695738302__r_c_1
 Connection: keep-alive
 ''')
+
+EASTMONEY_ETF_NET_VALUE_HEADER = chrome_copy_header_to_dict('''
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
+Referer: http://fund.eastmoney.com/
+''')

--- a/zvt/recorders/consts.py
+++ b/zvt/recorders/consts.py
@@ -120,3 +120,14 @@ Accept-Encoding: gzip, deflate
 Accept-Language: zh-CN,zh;q=0.8,en;q=0.6
 Cookie: yfx_c_g_u_id_10000042=_ck17122009304714819234313401740; VISITED_COMPANY_CODE=%5B%22000016%22%5D; VISITED_INDEX_CODE=%5B%22000016%22%5D; yfx_f_l_v_t_10000042=f_t_1513733447386__r_t_1515716891222__v_t_1515721033042__r_c_3; VISITED_MENU=%5B%228464%22%2C%229666%22%2C%229668%22%2C%229669%22%2C%228454%22%2C%228460%22%2C%229665%22%2C%228459%22%2C%229692%22%2C%228451%22%2C%228466%22%5D
 ''')
+
+DEFAULT_SH_ETF_LIST_HEADER = chrome_copy_header_to_dict('''
+Host: query.sse.com.cn
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
+Accept: */*
+Referer: http://www.sse.com.cn/assortment/fund/etf/list/
+Accept-Encoding: gzip, deflate
+Accept-Language: zh-CN,zh;q=0.9
+Cookie: yfx_c_g_u_id_10000042=_ck19062609443812815766114343798; VISITED_COMPANY_CODE=%5B%22510300%22%5D; VISITED_FUND_CODE=%5B%22510300%22%5D; VISITED_MENU=%5B%228307%22%2C%228823%22%2C%228547%22%2C%228556%22%2C%228549%22%2C%2210848%22%2C%228550%22%5D; yfx_f_l_v_t_10000042=f_t_1561513478278__r_t_1561692626758__v_t_1561695738302__r_c_1
+Connection: keep-alive
+''')

--- a/zvt/recorders/sina/china_etf_day_kdata_recorder.py
+++ b/zvt/recorders/sina/china_etf_day_kdata_recorder.py
@@ -64,8 +64,8 @@ class ChinaETFDayKdataRecorder(FixedCycleDataRecorder):
         return generate_kdata_id(security_id=security_item.id, timestamp=original_data['timestamp'], level=self.level)
 
     def generate_request_param(self, security_item, start, end, size, timestamp):
-        # 此 url 不支持指定日期，如果第一次获取，则取最大数据
-        if start is None:
+        # 此 url 不支持分页，如果超过我们想取的条数，则只能取最大条数
+        if start is None or size > self.default_size:
             size = 8000
 
         return {
@@ -128,5 +128,5 @@ class ChinaETFDayKdataRecorder(FixedCycleDataRecorder):
 
 if __name__ == '__main__':
     init_process_log('sina_china_etf_day_kdata.log')
-    ChinaETFDayKdataRecorder(level=TradingLevel.LEVEL_1DAY, codes=['159938']).run()
+    ChinaETFDayKdataRecorder(level=TradingLevel.LEVEL_1DAY).run()
 

--- a/zvt/recorders/sina/china_etf_day_kdata_recorder.py
+++ b/zvt/recorders/sina/china_etf_day_kdata_recorder.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+import demjson
+import logging
+import pandas as pd
+import requests
+
+from zvt.api.common import generate_kdata_id
+from zvt.recorders.consts import EASTMONEY_ETF_NET_VALUE_HEADER
+from zvt.api.technical import get_kdata
+from zvt.domain import Index, ETF1DKdata, Provider, SecurityType, StoreCategory, TradingLevel
+from zvt.recorders.recorder import ApiWrapper, FixedCycleDataRecorder, TimeSeriesFetchingStyle
+from zvt.utils.time_utils import to_time_str
+from zvt.utils.utils import init_process_log
+
+logger = logging.getLogger(__name__)
+
+
+class MyApiWrapper(ApiWrapper):
+    def request(self, url=None, method='post', param=None, path_fields=None):
+        security_item = param['security_item']
+        size = param['size']
+
+        url = url.format(security_item.exchange, security_item.code, size)
+
+        response = requests.get(url)
+        response_json = demjson.decode(response.text)
+
+        if response_json is None or len(response_json) == 0:
+            return []
+
+        df = pd.DataFrame(response_json)
+        df.rename(columns={'day': 'timestamp'}, inplace=True)
+        df['timestamp'] = pd.to_datetime(df['timestamp'])
+        df['name'] = security_item.name
+        df['provider'] = Provider.SINA.value
+        df['level'] = param['level']
+
+        return df.to_dict(orient='records')
+
+
+class ChinaETFDayKdataRecorder(FixedCycleDataRecorder):
+    meta_provider = Provider.EXCHANGE
+    meta_schema = Index
+
+    provider = Provider.SINA
+    store_category = StoreCategory.etf_1d_kdata
+    data_schema = ETF1DKdata
+    url = 'http://money.finance.sina.com.cn/quotes_service/api/json_v2.php/CN_MarketData.getKLineData?' \
+          'symbol={}{}&scale=240&&datalen={}&ma=no'
+    api_wrapper = MyApiWrapper()
+
+    def __init__(self, security_type=SecurityType.index, exchanges=['sh', 'sz'], codes=None, batch_size=10,
+                 force_update=False, sleeping_time=5, fetching_style=TimeSeriesFetchingStyle.end_size,
+                 default_size=2000, contain_unfinished_data=False, level=TradingLevel.LEVEL_1DAY,
+                 one_shot=True) -> None:
+        super().__init__(security_type, exchanges, codes, batch_size, force_update, sleeping_time, fetching_style,
+                         default_size, contain_unfinished_data, level, one_shot)
+
+    def get_data_map(self):
+        return {}
+
+    def generate_domain_id(self, security_item, original_data):
+        return generate_kdata_id(security_id=security_item.id, timestamp=original_data['timestamp'], level=self.level)
+
+    def generate_request_param(self, security_item, start, end, size, timestamp):
+        # 此 url 不支持指定日期，如果第一次获取，则取最大数据
+        if start is None:
+            size = 8000
+
+        return {
+            'security_item': security_item,
+            'level': self.level.value,
+            'size': size
+        }
+
+    def on_finish(self, security_item):
+        kdatas = get_kdata(security_id=security_item.id, data_schema=ETF1DKdata, level=TradingLevel.LEVEL_1DAY.value,
+                           order=ETF1DKdata.timestamp.asc(),
+                           return_type='domain', session=self.session,
+                           filters=[ETF1DKdata.cumulative_net_value.is_(None)])
+
+        if kdatas and len(kdatas) > 0:
+            start = kdatas[0].timestamp
+            end = kdatas[-1].timestamp
+
+            # 从东方财富获取基金累计净值
+            df = self.fetch_cumulative_net_value(security_item, start, end)
+
+            if df is not None and not df.empty:
+                for kdata in kdatas:
+                    if kdata.timestamp in df.index:
+                        kdata.cumulative_net_value = df.loc[kdata.timestamp, 'LJJZ']
+                        kdata.change_pct = df.loc[kdata.timestamp, 'JZZZL']
+                self.session.commit()
+                self.logger.info(f'{security_item.code} - {security_item.name}累计净值更新完成...')
+
+    def fetch_cumulative_net_value(self, security_item, start, end) -> pd.DataFrame:
+        query_url = 'http://api.fund.eastmoney.com/f10/lsjz?' \
+                    'fundCode={}&pageIndex={}&pageSize=200&startDate={}&endDate={}'
+
+        page = 1
+        df = pd.DataFrame()
+        while True:
+            url = query_url.format(security_item.code, page, to_time_str(start), to_time_str(end))
+
+            response = requests.get(url, headers=EASTMONEY_ETF_NET_VALUE_HEADER)
+            response_json = demjson.decode(response.text)
+            response_df = pd.DataFrame(response_json['Data']['LSJZList'])
+
+            # 最后一页
+            if response_df.empty:
+                break
+
+            response_df['FSRQ'] = pd.to_datetime(response_df['FSRQ'])
+            response_df['JZZZL'] = pd.to_numeric(response_df['JZZZL'], errors='coerce')
+            response_df['LJJZ'] = pd.to_numeric(response_df['LJJZ'], errors='coerce')
+            response_df = response_df.fillna(0)
+            response_df.set_index('FSRQ', inplace=True, drop=True)
+
+            df = pd.concat([df, response_df])
+            page += 1
+
+            self.sleep()
+
+        return df
+
+
+if __name__ == '__main__':
+    init_process_log('sina_china_etf_day_kdata.log')
+    ChinaETFDayKdataRecorder(level=TradingLevel.LEVEL_1DAY, codes=['159938']).run()
+


### PR DESCRIPTION
1.  增加沪深 ETF 列表抓取
2. 增加沪深 ETF 成分股抓取
3. 增加沪深 ETF 历史行行情抓取

有一个疑问的地方，不确定是否需要增加一个 `SecurityType` 的类型，如果直接用 `SecurityType.index` 的话，`get_security_schema ` 会取到错误的类型，因为 ETF 行情数据是存放在 ETF1DKdata 库，而非 Index1DKdata 库。