### PR TITLE
fix got an unexpected keyword argument 'entity_type' and TypeError: '>' not supported between instances of 'tuple' and 'int'

### DIFF
--- a/zvt/samples/stock_traders.py
+++ b/zvt/samples/stock_traders.py
@@ -28,7 +28,7 @@ class MyBullTrader(StockTrader):
                                     provider='joinquant')
 
         myselector.add_filter_factor(
-            BullFactor(entity_ids=entity_ids, entity_type=entity_schema, exchanges=exchanges,
+            BullFactor(entity_ids=entity_ids, entity_schema=entity_schema, exchanges=exchanges,
                        codes=codes, start_timestamp=start_timestamp, end_timestamp=end_timestamp))
 
         self.selectors.append(myselector)

--- a/zvt/trader/trader.py
+++ b/zvt/trader/trader.py
@@ -364,7 +364,7 @@ class Trader(object):
                     real_end_timestamp = timestamp
 
                 seconds = (now_pd_timestamp() - real_end_timestamp).total_seconds()
-                waiting_seconds = self.level.to_second() - seconds,
+                waiting_seconds = self.level.to_second() - seconds
                 # meaning the future kdata not ready yet,we could move on to check
                 if waiting_seconds > 0:
                     # iterate the selector from min to max which in finished timestamp kdata


### PR DESCRIPTION
跑sample的时候发现的错误，这个项目有点意思~
在python 3.7.0下因为 `waiting_seconds = self.level.to_second() - seconds,` 多了个逗号，让waiting_seconds变成tuple了

PS: 看了一晚上代码，设计简单明了，可以应用于扩展到任何的交易，加油~