### PR TITLE
fix: downgrade numpy to resolve compatibility issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ fastapi-pagination==0.12.23
 apscheduler==3.10.4
 eastmoneypy==0.1.7
 orjson==3.10.3
+numpy==1.26.4


### PR DESCRIPTION
The default installation of numpy version 2.0 caused an error on startup. Downgrading to version 1.26.4 resolved this issue.
![image](https://github.com/user-attachments/assets/66b463dc-f326-4179-975f-c33d986016c3)