### PR TITLE
fix: specify the numpy version to latest 1.x.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ fastapi-pagination==0.12.23
 apscheduler==3.10.4
 eastmoneypy==0.1.7
 orjson==3.10.3
+numpy>=1.26.0,<2.0


### PR DESCRIPTION
Hi, I just encountered the same problem as same as https://github.com/zvtvz/zvt/pull/213
The numpy is updated to 2.x and numpy 2.1.2 will be installed on a pure clean python environment, that will prevent the newbees to join this project.
So I create another PR...maybe use a lossy restriction will be more compatible.