### PR TITLE
Introducing ZVT Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Documentation Status](https://readthedocs.org/projects/zvt/badge/?version=latest)](https://zvt.readthedocs.io/en/latest/?badge=latest)
 [![codecov.io](https://codecov.io/github/zvtvz/zvt/coverage.svg?branch=master)](https://codecov.io/github/zvtvz/zvt)
 [![Downloads](https://pepy.tech/badge/zvt/month)](https://pepy.tech/project/zvt)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20ZVT%20Guru-006BFF)](https://gurubase.io/g/zvt)
 
 **The origin of ZVT**
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ZVT Guru](https://gurubase.io/g/zvt) to Gurubase. ZVT Guru uses the data from this repo and data from the [docs](https://zvt.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "ZVT Guru", which highlights that ZVT now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ZVT Guru in Gurubase, just let me know that's totally fine.
