### PR TITLE
Update wb_economy_recorder.py（获取不到数据报错问题），Update em_api.py（最小数据间隔改为1m）

### DIFF
--- a/src/zvt/recorders/em/em_api.py
+++ b/src/zvt/recorders/em/em_api.py
@@ -966,9 +966,11 @@ def to_em_fq_flag(adjust_type: AdjustType):
 
 def to_em_level_flag(level: IntervalLevel):
     level = IntervalLevel(level)
-    if level == IntervalLevel.LEVEL_5MIN:
+    if level == IntervalLevel.LEVEL_1MIN:
+        return 1
+    elif level == IntervalLevel.LEVEL_5MIN:
         return 5
-    if level == IntervalLevel.LEVEL_15MIN:
+    elif level == IntervalLevel.LEVEL_15MIN:
         return 15
     elif level == IntervalLevel.LEVEL_30MIN:
         return 30

--- a/src/zvt/recorders/wb/wb_economy_recorder.py
+++ b/src/zvt/recorders/wb/wb_economy_recorder.py
@@ -17,9 +17,13 @@ class WBEconomyRecorder(FixedCycleDataRecorder):
         date = None
         if start:
             date = f"{start.year}:{current_date().year}"
-        df = wb_api.get_economy_data(entity_id=entity.id, date=date)
-        df["name"] = entity.name
-        df_to_db(df=df, data_schema=self.data_schema, provider=self.provider, force_update=self.force_update)
+        try:
+            df = wb_api.get_economy_data(entity_id=entity.id, date=date)
+            df["name"] = entity.name
+            df_to_db(df=df, data_schema=self.data_schema, provider=self.provider, force_update=self.force_update)
+        # 一些地方获取不到数据会报错
+        except Exception as e:
+            print(e)s
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Update wb_economy_recorder.py
一些地方获取数据会报错，比如第四个数据，它的id是
entity.id=country_galaxy_6F
entity.name=IDA countries classified as fragile situations, excluding Sub-Saharan Africa
获取其数据时就会报错：
The request returned no data:
url=http://api.worldbank.org/v2/country/6F/indicator/SP.POP.TOTL

3. Update em_api.py（最小数据间隔改为1m）
em源的1m数据需要调整这个level的获取验证函数，
原来的函数最小数据为5m。