### PR TITLE
Add FXMacroData currency recorder

### DIFF
--- a/src/zvt/recorders/__init__.py
+++ b/src/zvt/recorders/__init__.py
@@ -100,6 +100,12 @@ from .exchange import __all__ as _exchange_all
 
 __all__ += _exchange_all
 
+# import all from submodule fxmacrodata
+from .fxmacrodata import *
+from .fxmacrodata import __all__ as _fxmacrodata_all
+
+__all__ += _fxmacrodata_all
+
 # import all from submodule wb
 from .wb import *
 from .wb import __all__ as _wb_all

--- a/src/zvt/recorders/fxmacrodata/__init__.py
+++ b/src/zvt/recorders/fxmacrodata/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from .fxmacrodata_api import *
+from .fxmacrodata_api import __all__ as _fxmacrodata_api_all
+from .meta.fxmacrodata_currency_meta_recorder import *
+from .meta.fxmacrodata_currency_meta_recorder import __all__ as _meta_all
+from .quotes.fxmacrodata_currency_kdata_recorder import *
+from .quotes.fxmacrodata_currency_kdata_recorder import __all__ as _quotes_all
+
+__all__ = []
+__all__ += _fxmacrodata_api_all
+__all__ += _meta_all
+__all__ += _quotes_all

--- a/src/zvt/recorders/fxmacrodata/fxmacrodata_api.py
+++ b/src/zvt/recorders/fxmacrodata/fxmacrodata_api.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+import os
+
+import pandas as pd
+import requests
+
+from zvt.api.kdata import generate_kdata_id
+from zvt.contract import Exchange, IntervalLevel, TradableType
+from zvt.contract.api import decode_entity_id
+from zvt.utils.time_utils import to_pd_timestamp
+
+PROVIDER = "fxmacrodata"
+FXMACRODATA_API_BASE_URL = "https://fxmacrodata.com/api/v1"
+FXMACRODATA_API_KEY_ENV_VARS = ("FXMACRODATA_API_KEY", "FXMD_API_KEY")
+FXMACRODATA_DEFAULT_CURRENCY_PAIRS = [
+    "AUDUSD",
+    "BRLUSD",
+    "CADUSD",
+    "CHFUSD",
+    "CNHUSD",
+    "CNYUSD",
+    "DKKUSD",
+    "EURUSD",
+    "GBPUSD",
+    "IDRUSD",
+    "ILSUSD",
+    "JPYUSD",
+    "NGNUSD",
+    "NOKUSD",
+    "NZDUSD",
+    "PENUSD",
+    "SEKUSD",
+    "THBUSD",
+]
+
+
+def to_currency_entity_id(code):
+    return f"{TradableType.currency.value}_{Exchange.forex.value}_{normalize_currency_pair(code)}"
+
+
+def normalize_currency_pair(code):
+    normalized = "".join(char for char in str(code).upper() if char.isalpha())
+    if len(normalized) != 6:
+        raise ValueError("currency pair must look like EURUSD or EUR/USD")
+    return normalized
+
+
+def get_currency_list(codes=None):
+    if codes is None:
+        codes = FXMACRODATA_DEFAULT_CURRENCY_PAIRS
+
+    rows = []
+    for raw_code in codes:
+        code = normalize_currency_pair(raw_code)
+        entity_id = to_currency_entity_id(code)
+        rows.append(
+            {
+                "id": entity_id,
+                "entity_id": entity_id,
+                "entity_type": TradableType.currency.value,
+                "exchange": Exchange.forex.value,
+                "code": code,
+                "name": code,
+            }
+        )
+
+    return pd.DataFrame.from_records(rows)
+
+
+def get_kdata(
+    entity_id,
+    session=None,
+    start_timestamp=None,
+    end_timestamp=None,
+    api_key=None,
+    base_url=FXMACRODATA_API_BASE_URL,
+    timeout=30,
+):
+    entity_type, _, code = decode_entity_id(entity_id)
+    if entity_type != TradableType.currency.value:
+        raise ValueError(f"FXMacroData only supports currency entities, got {entity_id}")
+
+    code = normalize_currency_pair(code)
+    base_currency = code[:3].lower()
+    quote_currency = code[3:].lower()
+    params = _query_params(start_timestamp, end_timestamp, api_key)
+    url = f"{base_url.rstrip('/')}/forex/{base_currency}/{quote_currency}"
+
+    http = session or requests
+    response = http.get(
+        url,
+        params=params,
+        headers={"Accept": "application/json"},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    close_response(response)
+
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise ValueError("FXMacroData response did not include a data list")
+
+    kdatas = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        date_value = row.get("date")
+        price_value = row.get("val")
+        if date_value is None or price_value is None:
+            continue
+        timestamp = to_pd_timestamp(date_value)
+        price = float(price_value)
+        kdatas.append(
+            {
+                "id": generate_kdata_id(
+                    entity_id=entity_id,
+                    timestamp=timestamp,
+                    level=IntervalLevel.LEVEL_1DAY,
+                ),
+                "timestamp": timestamp,
+                "entity_id": entity_id,
+                "provider": PROVIDER,
+                "code": code,
+                "name": code,
+                "level": IntervalLevel.LEVEL_1DAY.value,
+                "open": price,
+                "close": price,
+                "high": price,
+                "low": price,
+                "volume": 0.0,
+                "turnover": 0.0,
+                "turnover_rate": 0.0,
+            }
+        )
+
+    if kdatas:
+        return pd.DataFrame.from_records(kdatas).sort_values("timestamp")
+
+
+def close_response(response):
+    close = getattr(response, "close", None)
+    if close:
+        close()
+
+
+def _query_params(start_timestamp, end_timestamp, api_key):
+    params = {}
+    if start_timestamp is not None:
+        params["start_date"] = _date_param(start_timestamp)
+    if end_timestamp is not None:
+        params["end_date"] = _date_param(end_timestamp)
+
+    api_key = api_key or _api_key_from_environment()
+    if api_key:
+        params["api_key"] = api_key
+
+    return params
+
+
+def _date_param(value):
+    return to_pd_timestamp(value).date().isoformat()
+
+
+def _api_key_from_environment():
+    for env_var in FXMACRODATA_API_KEY_ENV_VARS:
+        api_key = os.getenv(env_var)
+        if api_key:
+            return api_key
+    return None
+
+
+__all__ = [
+    "PROVIDER",
+    "FXMACRODATA_API_BASE_URL",
+    "FXMACRODATA_DEFAULT_CURRENCY_PAIRS",
+    "get_currency_list",
+    "get_kdata",
+    "normalize_currency_pair",
+    "to_currency_entity_id",
+]

--- a/src/zvt/recorders/fxmacrodata/meta/__init__.py
+++ b/src/zvt/recorders/fxmacrodata/meta/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from .fxmacrodata_currency_meta_recorder import *
+from .fxmacrodata_currency_meta_recorder import __all__ as _currency_meta_all
+
+__all__ = []
+__all__ += _currency_meta_all

--- a/src/zvt/recorders/fxmacrodata/meta/fxmacrodata_currency_meta_recorder.py
+++ b/src/zvt/recorders/fxmacrodata/meta/fxmacrodata_currency_meta_recorder.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from zvt.contract.api import df_to_db
+from zvt.contract.recorder import Recorder
+from zvt.domain.meta.currency_meta import Currency
+from zvt.recorders.fxmacrodata import fxmacrodata_api
+
+
+class FXMacroDataCurrencyRecorder(Recorder):
+    provider = fxmacrodata_api.PROVIDER
+    data_schema = Currency
+
+    def __init__(self, codes=None, force_update=False, sleeping_time=10) -> None:
+        self.codes = codes
+        super().__init__(force_update=force_update, sleeping_time=sleeping_time)
+
+    def run(self):
+        df = fxmacrodata_api.get_currency_list(codes=self.codes)
+        df_to_db(
+            df=df,
+            data_schema=self.data_schema,
+            provider=self.provider,
+            force_update=self.force_update,
+        )
+
+
+if __name__ == "__main__":
+    recorder = FXMacroDataCurrencyRecorder(force_update=True)
+    recorder.run()
+
+
+__all__ = ["FXMacroDataCurrencyRecorder"]

--- a/src/zvt/recorders/fxmacrodata/quotes/__init__.py
+++ b/src/zvt/recorders/fxmacrodata/quotes/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from .fxmacrodata_currency_kdata_recorder import *
+from .fxmacrodata_currency_kdata_recorder import __all__ as _currency_kdata_all
+
+__all__ = []
+__all__ += _currency_kdata_all

--- a/src/zvt/recorders/fxmacrodata/quotes/fxmacrodata_currency_kdata_recorder.py
+++ b/src/zvt/recorders/fxmacrodata/quotes/fxmacrodata_currency_kdata_recorder.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from zvt.contract import IntervalLevel
+from zvt.contract.recorder import FixedCycleDataRecorder
+from zvt.domain.meta.currency_meta import Currency
+from zvt.domain.quotes.currency.currency_1d_kdata import Currency1dKdata
+from zvt.recorders.fxmacrodata import fxmacrodata_api
+from zvt.utils.pd_utils import pd_is_not_null
+
+
+class FXMacroDataCurrencyKdataRecorder(FixedCycleDataRecorder):
+    provider = fxmacrodata_api.PROVIDER
+    entity_provider = fxmacrodata_api.PROVIDER
+    entity_schema = Currency
+    data_schema = Currency1dKdata
+
+    def __init__(
+        self,
+        api_key=None,
+        base_url=fxmacrodata_api.FXMACRODATA_API_BASE_URL,
+        timeout=30,
+        **kwargs,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url
+        self.timeout = timeout
+        super().__init__(level=IntervalLevel.LEVEL_1DAY, **kwargs)
+
+    def record(self, entity, start, end, size, timestamps):
+        df = fxmacrodata_api.get_kdata(
+            entity_id=entity.id,
+            session=self.http_session,
+            start_timestamp=start,
+            end_timestamp=end,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            timeout=self.timeout,
+        )
+        if pd_is_not_null(df):
+            return df.to_dict("records")
+        return []
+
+
+__all__ = ["FXMacroDataCurrencyKdataRecorder"]

--- a/tests/test_fxmacrodata_recorder.py
+++ b/tests/test_fxmacrodata_recorder.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+import pandas as pd
+
+from zvt.recorders.fxmacrodata import fxmacrodata_api
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+        self.closed = False
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return self.response
+
+
+def test_get_currency_list():
+    df = fxmacrodata_api.get_currency_list(codes=["eur/usd"])
+
+    assert df.to_dict("records") == [
+        {
+            "id": "currency_forex_EURUSD",
+            "entity_id": "currency_forex_EURUSD",
+            "entity_type": "currency",
+            "exchange": "forex",
+            "code": "EURUSD",
+            "name": "EURUSD",
+        }
+    ]
+
+
+def test_get_kdata_fetches_fxmacrodata_prices():
+    response = FakeResponse(
+        {
+            "data": [
+                {"date": "2024-01-03", "val": 1.092},
+                {"date": "2024-01-01", "val": "1.1038"},
+            ]
+        }
+    )
+    session = FakeSession(response=response)
+
+    df = fxmacrodata_api.get_kdata(
+        entity_id="currency_forex_EURUSD",
+        session=session,
+        start_timestamp="2024-01-01",
+        end_timestamp="2024-01-31",
+        api_key="test-key",
+        timeout=12,
+    )
+
+    assert session.calls == [
+        {
+            "url": "https://fxmacrodata.com/api/v1/forex/eur/usd",
+            "params": {
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+                "api_key": "test-key",
+            },
+            "headers": {"Accept": "application/json"},
+            "timeout": 12,
+        }
+    ]
+    assert response.closed
+    assert df["id"].tolist() == [
+        "currency_forex_EURUSD_2024-01-01",
+        "currency_forex_EURUSD_2024-01-03",
+    ]
+    assert df["provider"].tolist() == ["fxmacrodata", "fxmacrodata"]
+    assert df["level"].tolist() == ["1d", "1d"]
+    assert df["code"].tolist() == ["EURUSD", "EURUSD"]
+    assert df["open"].tolist() == [1.1038, 1.092]
+    assert df["high"].tolist() == [1.1038, 1.092]
+    assert df["low"].tolist() == [1.1038, 1.092]
+    assert df["close"].tolist() == [1.1038, 1.092]
+    assert df["volume"].tolist() == [0.0, 0.0]
+    assert df["timestamp"].tolist() == [
+        pd.Timestamp("2024-01-01"),
+        pd.Timestamp("2024-01-03"),
+    ]


### PR DESCRIPTION
## Summary
- adds an `fxmacrodata` recorder provider package
- adds currency metadata and daily currency kdata recorders for FXMacroData
- maps FXMacroData `/api/v1/forex/{base}/{quote}` responses into zvt currency entities and close-only daily OHLC rows
- supports explicit `api_key` plus `FXMACRODATA_API_KEY` / `FXMD_API_KEY` environment variables using query-parameter auth

## Validation
- `PYTHONPATH=src python -m pytest --rootdir=. tests\test_fxmacrodata_recorder.py -q`
- `python -m compileall -q src\zvt\recorders\__init__.py src\zvt\recorders\fxmacrodata tests\test_fxmacrodata_recorder.py`
- `git diff --check`
- `python -m black --check --line-length 120 src\zvt\recorders\__init__.py src\zvt\recorders\fxmacrodata tests\test_fxmacrodata_recorder.py`

Note: local test collection needed `jqdatapy==0.1.8` and `demjson3==3.0.6`, which are already declared zvt runtime dependencies.